### PR TITLE
Use AddDbContextPool

### DIFF
--- a/solardash.Server/Program.cs
+++ b/solardash.Server/Program.cs
@@ -5,9 +5,9 @@ using solardash.Server;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Register SolarDbContext and configure PostgreSQL connection
-// This allows EF Core to connect to PostgreSQL using connection string from appsettings.json. Scope by default
-builder.Services.AddDbContext<SolarDbContext>(options =>
+// Register SolarDbContext with pooling and configure PostgreSQL connection
+// AddDbContextPool enables DbContext pooling which can improve performance
+builder.Services.AddDbContextPool<SolarDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 // Add support for minimal API endpoint discovery


### PR DESCRIPTION
## Summary
- use `AddDbContextPool` instead of `AddDbContext`
- update comments to mention DbContext pooling

## Testing
- `dotnet build solardash.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684084b756408333b4e82581c6d24413